### PR TITLE
Refactor: searchParams로 검색하도록 변경, InfiniteScrollTrigger 컴포넌트 분리

### DIFF
--- a/src/components/InfinitScrollTrigger/index.tsx
+++ b/src/components/InfinitScrollTrigger/index.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Spinner from "@/components/fallbacks/Spinner";
+import useIntersectionObserver from "@/hooks/useIntersectionObserver";
+
+interface Props {
+  fetchNextPage: any;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+}
+
+function InfiniteScrollTrigger({
+  fetchNextPage,
+  isFetchingNextPage,
+  hasNextPage,
+}: Props) {
+  const { targetRef } = useIntersectionObserver({
+    onIntersect: fetchNextPage,
+  });
+
+  return (
+    <>
+      {isFetchingNextPage && <Spinner />}
+      {hasNextPage && !isFetchingNextPage && <div ref={targetRef}></div>}
+    </>
+  );
+}
+
+export default InfiniteScrollTrigger;

--- a/src/components/SearchBooks/index.test.tsx
+++ b/src/components/SearchBooks/index.test.tsx
@@ -1,12 +1,26 @@
 import { act, fireEvent, waitFor } from "@testing-library/react";
+import * as navigation from "next/navigation";
 import * as api from "@/api";
-import SearchBooks from ".";
 import { customRender } from "@/utils/testUtils";
+import SearchBooks from ".";
 
 jest.mock("@/hooks/useIntersectionObserver", () => ({
   __esModule: true,
   default: jest.fn(() => ({ targetRef: { current: {} } })),
 }));
+jest.mock("next/navigation");
+
+const routerPushMockFn = jest.fn();
+
+beforeEach(() => {
+  (navigation.useRouter as jest.Mock).mockImplementation(() => ({
+    push: routerPushMockFn,
+  }));
+  (navigation.useSearchParams as jest.Mock).mockImplementation(
+    () => new URLSearchParams({})
+  );
+  (navigation.usePathname as jest.Mock).mockImplementation(() => "/");
+});
 
 jest.mock("@/api", () => ({
   searchBooks: jest.fn().mockImplementation(({ keyword }) => {
@@ -44,10 +58,15 @@ jest.mock("@/api", () => ({
 }));
 
 describe("SearchBooks 테스트", () => {
-  it("검색 결과에는 title, image, url, subtitle이 표시되어야 한다", () => {
+  it("검색 결과에는 title, image, url, subtitle이 표시되어야 한다", async () => {
+    (navigation.useSearchParams as jest.Mock).mockImplementation(
+      () => new URLSearchParams({ keywords: "python" })
+    );
+
     const { getByText, getByPlaceholderText, getByAltText } = customRender(
       <SearchBooks />
     );
+
     const inputField = getByPlaceholderText("검색어를 입력하세요");
     const submitButton = getByText("검색");
 
@@ -56,7 +75,8 @@ describe("SearchBooks 테스트", () => {
       fireEvent.click(submitButton);
     });
 
-    waitFor(() => {
+    await waitFor(() => {
+      expect(routerPushMockFn).toHaveBeenCalledWith("/?keywords=python");
       expect(getByText("Book for python 1")).toBeInTheDocument();
       expect(getByText("Subtitle for python 2")).toBeInTheDocument();
       expect(getByText("url for python 2")).toBeInTheDocument();
@@ -65,6 +85,9 @@ describe("SearchBooks 테스트", () => {
   });
 
   it("하나의 키워드만 입력하면 해당 키워드의 검색 결과를 표시한다", async () => {
+    (navigation.useSearchParams as jest.Mock).mockImplementation(
+      () => new URLSearchParams({ keywords: "python" })
+    );
     const { getByText, getByPlaceholderText } = customRender(<SearchBooks />);
     const inputField = getByPlaceholderText("검색어를 입력하세요");
     const submitButton = getByText("검색");
@@ -75,6 +98,7 @@ describe("SearchBooks 테스트", () => {
     });
 
     await waitFor(() => {
+      expect(routerPushMockFn).toHaveBeenCalledWith("/?keywords=python");
       expect(api.searchBooks).toHaveBeenCalledWith({
         keyword: "python",
         page: 1,
@@ -85,6 +109,9 @@ describe("SearchBooks 테스트", () => {
   });
 
   it("| 연산자를 포함한 두 개의 키워드를 입력하면 각각의 키워드 검색 결과를 합쳐 표시한다", async () => {
+    (navigation.useSearchParams as jest.Mock).mockImplementation(
+      () => new URLSearchParams({ keywords: "python|mongo" })
+    );
     const { getByText, getByPlaceholderText } = customRender(<SearchBooks />);
     const inputField = getByPlaceholderText("검색어를 입력하세요");
     const submitButton = getByText("검색");
@@ -103,6 +130,9 @@ describe("SearchBooks 테스트", () => {
   });
 
   it("- 연산자를 포함해 두 개의 키워드를 입력하면 첫번째 키워드 검색 결과에서 두 번째 키워드를 포함한 제목을 갖는 결과를 제외해 표시한다", async () => {
+    (navigation.useSearchParams as jest.Mock).mockImplementation(
+      () => new URLSearchParams({ keywords: "python-2" })
+    );
     const { getByText, queryByText, getByPlaceholderText } = customRender(
       <SearchBooks />
     );
@@ -121,6 +151,9 @@ describe("SearchBooks 테스트", () => {
   });
 
   it("검색 결과가 없으면 결과 없음 UI가 표시된다", async () => {
+    (navigation.useSearchParams as jest.Mock).mockImplementation(
+      () => new URLSearchParams({ keywords: "noData" })
+    );
     const { getByText, getByPlaceholderText } = customRender(<SearchBooks />);
     const inputField = getByPlaceholderText("검색어를 입력하세요");
     const submitButton = getByText("검색");

--- a/src/components/SearchBooks/index.tsx
+++ b/src/components/SearchBooks/index.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import React, { Fragment, useState } from "react";
+import React, { Fragment } from "react";
 import { BookData } from "@/types";
 import { useSearchBooksQuery } from "@/queries";
+import useQueryString from "@/hooks/useQueryString";
 import Book from "@/components/Book";
 import NoDataFallback from "@/components/fallbacks/NoDataFallback";
 import BookList from "@/components/BookList";
 import SearchInput from "@/components/SearchInput";
 import InfiniteScrollTrigger from "@/components/InfinitScrollTrigger";
+import { SEARCH_PARAMS_KEY } from "@/constants";
 
 function SearchBooks() {
-  const [keywords, setKeywords] = useState("");
+  const { getSearchParams, updateSearchParams } = useQueryString();
 
+  const keywords = getSearchParams(SEARCH_PARAMS_KEY.KEYWORDS);
   const { data, fetchNextPage, isLoading, hasNextPage, isFetchingNextPage } =
     useSearchBooksQuery({ keywords });
 
@@ -19,7 +22,7 @@ function SearchBooks() {
   const hasSearchResults = !!(!isLoading && keywords.length);
 
   const handleSubmit = (text: string) => {
-    setKeywords(text);
+    updateSearchParams(SEARCH_PARAMS_KEY.KEYWORDS, text);
   };
 
   return (

--- a/src/components/SearchBooks/index.tsx
+++ b/src/components/SearchBooks/index.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useState } from "react";
 import { BookData } from "@/types";
 import { useSearchBooksQuery } from "@/queries";
-import useIntersectionObserver from "@/hooks/useIntersectionObserver";
 import Book from "@/components/Book";
 import NoDataFallback from "@/components/fallbacks/NoDataFallback";
 import BookList from "@/components/BookList";
 import SearchInput from "@/components/SearchInput";
-import Spinner from "@/components/fallbacks/Spinner";
+import InfiniteScrollTrigger from "@/components/InfinitScrollTrigger";
 
 function SearchBooks() {
   const [keywords, setKeywords] = useState("");
@@ -19,23 +18,14 @@ function SearchBooks() {
   const hasNoSearchResults = !data?.pages[0].books.length;
   const hasSearchResults = !!(!isLoading && keywords.length);
 
-  const { targetRef } = useIntersectionObserver({
-    onIntersect: fetchNextPage,
-  });
-
   const handleSubmit = (text: string) => {
     setKeywords(text);
   };
-
-  useEffect(() => {
-    fetchNextPage();
-  }, [keywords, fetchNextPage]);
 
   return (
     <div className="flex min-h-screen flex-col items-center p-24 lg:min-w-[1000px]">
       <SearchInput onSubmit={handleSubmit} />
       <div className="w-full py-12 min-w-[500px]">
-        {isLoading && <Spinner />}
         {hasSearchResults && (
           <>
             <BookList title="검색 결과">
@@ -55,17 +45,18 @@ function SearchBooks() {
               ))}
             </BookList>
 
+            <InfiniteScrollTrigger
+              fetchNextPage={fetchNextPage}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+            />
+
             {hasNoSearchResults && (
               <NoDataFallback text="검색 결과가 없습니다" />
             )}
           </>
         )}
       </div>
-
-      {isFetchingNextPage && <Spinner />}
-      {hasNextPage && !isFetchingNextPage && (
-        <div ref={targetRef} className="h-200px bg-slate-500"></div>
-      )}
     </div>
   );
 }

--- a/src/components/providers/Provider/index.tsx
+++ b/src/components/providers/Provider/index.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import React from "react";
-import { QueryClientProvider } from "@tanstack/react-query";
+import React, { useState } from "react";
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import getQueryClient from "@/utils/getQueryClient";
 
 function Providers({ children }: React.PropsWithChildren) {
-  const client = getQueryClient();
+  const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <QueryClientProvider client={client}>
+    <QueryClientProvider client={queryClient}>
       {children}
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/src/components/providers/Provider/index.tsx
+++ b/src/components/providers/Provider/index.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import React from "react";
-import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import getQueryClient from "@/utils/getQueryClient";
 
 function Providers({ children }: React.PropsWithChildren) {
-  const [client] = React.useState(
-    new QueryClient({ defaultOptions: { queries: { staleTime: 5000 } } })
-  );
+  const client = getQueryClient();
 
   return (
     <QueryClientProvider client={client}>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,5 @@
 export const API_SERVER = "https://api.itbook.store/1.0";
+
+export const SEARCH_PARAMS_KEY = {
+  KEYWORDS: "keywords",
+};

--- a/src/hooks/useQueryString.ts
+++ b/src/hooks/useQueryString.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+function useQueryString() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams);
+      params.set(name, value);
+
+      return params.toString();
+    },
+    [searchParams]
+  );
+
+  const getSearchParams = (key: string) => {
+    return decodeURI(searchParams.get(key) || "");
+  };
+
+  const updateSearchParams = (key: string, value: string) => {
+    router.push(pathname + "?" + createQueryString(key, encodeURI(value)));
+  };
+
+  return { getSearchParams, updateSearchParams };
+}
+
+export default useQueryString;

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,5 +1,6 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { getBook, searchBooks } from "@/api";
+import { SearchBookResponse } from "@/types";
 import { splitKeywords } from "@/utils/handleKeywords";
 import { bookQueryKeys, searchBookQueryKeys } from "./queryKeys";
 
@@ -13,8 +14,9 @@ const handleResultsWithOrOp = (keywords: string, pageParam: number) => {
     const mergedResults = results.flatMap((result) => result.books);
     return {
       books: mergedResults,
-      page: pageParam,
+      page: pageParam.toString(),
       total: results[pageParam].total,
+      error: "0",
     };
   });
 };
@@ -30,8 +32,9 @@ const handleResultsWithNotOp = async (keywords: string, pageParam: number) => {
   });
   return {
     books: filteredBooks,
-    page: pageParam,
+    page: pageParam.toString(),
     total: searchedBooks.total,
+    error: "0",
   };
 };
 
@@ -43,17 +46,20 @@ export const useSearchBooksQuery = ({ keywords }: { keywords: string }) => {
       const hasNotOperator = keywords.includes("-");
 
       if (hasOrOperator) {
-        return handleResultsWithOrOp(keywords, pageParam);
+        return await handleResultsWithOrOp(keywords, pageParam);
       }
 
       if (hasNotOperator) {
-        return handleResultsWithNotOp(keywords, pageParam);
+        return await handleResultsWithNotOp(keywords, pageParam);
       }
 
-      return searchBooks({ keyword: keywords, page: pageParam });
+      return await searchBooks({
+        keyword: keywords,
+        page: pageParam,
+      });
     },
-    getNextPageParam: (lastPage: any) => {
-      const nextPage = lastPage.page + 1;
+    getNextPageParam: (lastPage: SearchBookResponse) => {
+      const nextPage = parseInt(lastPage.page) + 1;
       const totalItems = parseInt(lastPage.total);
       if (nextPage * 10 <= totalItems) {
         return nextPage;


### PR DESCRIPTION
### Description

#### 주요 변경 사항
- SRP (단일책임원칙)에 따라, SearchBooks 컴포넌트에서 무한스크롤과 관련된 로직 (useIntersectionObserver, 조건에 따른 trigger요소 렌더링 등)에 대한 세부사항까지 다루지 않도록 별도 컴포넌트 InfiniteScrollTrigger 선언해 분리
  - 커스텀 훅 useIntersectionObserver을 사용해 SearchBooks 컴포넌트 내에서 무한스크롤 기능을 구현하면 컴포넌트 응집도가 떨어져, 해당 로직 캡슐화하도록 리팩토링
- fetchNextPage 타입오류 해결
- queryClient 관리로직 수정
- state 대신 searchParams를 사용해 검색어 키워드 관리하도록 변경
  - 상세페이지에서 뒤로 가기해도 검색어 유지
  - 사용자가 검색 화면을 공유할 수 있음
<br>

#### 스크린샷

<br>

#### Todo

<br>

#### 테스트

<br>
